### PR TITLE
Tighter crop, works fine with VISTA. Will check with KiDS.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ProPane
 Type: Package
 Title: Image Warping and Stacking
 Version: 1.1.2
-Date: 2023-02-07
+Date: 2023-02-09
 Authors@R: c(
     person(given='Aaron', family='Robotham', email='aaron.robotham@uwa.edu.au',
         role=c('aut', 'cre'), comment=c(ORCID='0000-0003-0429-3579')),
@@ -11,7 +11,7 @@ Authors@R: c(
 Maintainer: Aaron Robotham <aaron.robotham@uwa.edu.au>
 Description: Warping and flat image stacking utilities.
 License: LGPL-3
-Imports: Rcpp, Rfits (>= 1.7.7), Rwcs (>= 1.6.0), checkmate, magicaxis, foreach, doParallel, data.table
+Imports: Rcpp, Rfits (>= 1.7.7), Rwcs (>= 1.6.1), checkmate, magicaxis, foreach, doParallel, data.table
 Suggests: testthat, imager, knitr, Rfast2, ProFound
 Encoding: UTF-8
 LazyData: true

--- a/R/propaneStackWarpMed.R
+++ b/R/propaneStackWarpMed.R
@@ -67,7 +67,7 @@ propaneStackWarpMed = function(
     NAXIS2 = dim(image_list[[1]])[2]
   }
 
-  stack_grid = expand.grid(seq(1,NAXIS1,by=chunk), seq(1,NAXIS2,by=chunk))
+  stack_grid = expand.grid(seq(1L,NAXIS1,by=chunk), seq(1L,NAXIS2,by=chunk))
   stack_grid[,3] = stack_grid[,1] + chunk
   stack_grid[stack_grid[,3] > NAXIS1,3] = NAXIS1
   stack_grid[,4] = stack_grid[,2] + chunk

--- a/R/propaneWarp.R
+++ b/R/propaneWarp.R
@@ -1,20 +1,19 @@
-.warpfunc_in2out = function(x, y, keyvalues_in=NULL, header_in=NULL, WCSref_in=NULL, keyvalues_out=NULL, raw_out=NULL, WCSref_out=NULL) {
-  radectemp = Rwcs_p2s(x, y, keyvalues = keyvalues_in, header = header_in, WCSref = WCSref_in)
-  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], keyvalues = keyvalues_out, header = raw_out, WCSref = WCSref_out)
+.warpfunc_in2out = function(x, y, keyvalues_in=NULL, header_in=NULL, WCSref_in=NULL, keyvalues_out=NULL, raw_out=NULL, WCSref_out=NULL, cores=1) {
+  radectemp = Rwcs_p2s(x, y, keyvalues = keyvalues_in, header = header_in, WCSref = WCSref_in, cores = cores)
+  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], keyvalues = keyvalues_out, header = raw_out, WCSref = WCSref_out, cores = cores)
   return(xy_out)
 }
-.warpfunc_out2in = function(x, y, keyvalues_in=NULL, header_in=NULL, WCSref_in=NULL, keyvalues_out=NULL, raw_out=NULL, WCSref_out=NULL) {
-  radectemp = Rwcs_p2s(x, y, keyvalues = keyvalues_out, header = raw_out, WCSref = WCSref_in)
-  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], keyvalues = keyvalues_in, header = header_in, WCSref = WCSref_out)
+.warpfunc_out2in = function(x, y, keyvalues_in=NULL, header_in=NULL, WCSref_in=NULL, keyvalues_out=NULL, raw_out=NULL, WCSref_out=NULL, cores=1) {
+  radectemp = Rwcs_p2s(x, y, keyvalues = keyvalues_out, header = raw_out, WCSref = WCSref_in, cores = cores)
+  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], keyvalues = keyvalues_in, header = header_in, WCSref = WCSref_out, cores = cores)
   return(xy_out)
 }
 
-propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_out = NULL,
-                      pixscale_out = NULL, pixscale_in = NULL,
+propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
                       direction = "auto", boundary = "dirichlet", interpolation = "cubic",
-                      doscale = TRUE, dofinenorm = TRUE, plot = FALSE, header_out = NULL, header_in = NULL, dotightcrop = TRUE,
-                      keepcrop=FALSE, WCSref_out = NULL, WCSref_in = NULL, magzero_out = NULL, magzero_in = NULL,
-                      blank=NA, warpfield=NULL, warpfield_return=FALSE, ...)
+                      doscale = TRUE, dofinenorm = TRUE, plot = FALSE, header_out = NULL, dotightcrop = TRUE,
+                      keepcrop = FALSE, WCSref_out = NULL, WCSref_in = NULL, magzero_out = NULL, magzero_in = NULL,
+                      blank=NA, warpfield=NULL, warpfield_return=FALSE, cores=1, ...)
 {
   if(!requireNamespace("Rwcs", quietly = TRUE)){
     stop("The Rwcs package is needed for this function to work. Please install it from GitHub asgr/Rwcs", call. = FALSE)
@@ -28,53 +27,32 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
     stop("The Rfits package is needed for this function to work. Please install it from GitHub asgr/Rfits", call. = FALSE)
   }
 
-  if(inherits(image_in, 'Rfits_pointer')){
-    image_in = image_in[,]
+  if(! inherits(image_in, c('Rfits_image', 'Rfits_pointer'))){
+    stop('image_in must be either Rfits_image or Rfits_pointer!')
   }
 
-  if(any(names(image_in)=='imDat') | any(names(image_in)=='image')){
-    if(is.null(header_in)){
-      if(is.null(keyvalues_in)){
-        keyvalues_in = image_in$keyvalues
-      }
-      if(is.null(image_in$raw)){
-        header_in = image_in$hdr
-      }else{
-        header_in = image_in$raw
-      }
-    }
-
-    if(any(names(image_in)=='imDat')){
-      image_in = image_in$imDat
-    }
-
-    if(any(names(image_in)=='image')){
-      image_in = image_in$image
-    }
+  keyvalues_in = image_in$keyvalues
+  if(is.null(image_in$raw)){
+    header_in = image_in$hdr
+  }else{
+    header_in = image_in$raw
   }
 
   if(is.character(header_out)){
-    if(requireNamespace("Rfits", quietly = TRUE)){
-      if(length(header_out) == 1){
-        keyvalues_out = Rfits::Rfits_header_to_keyvalues(Rfits::Rfits_raw_to_header(header_out))
-      }else if(length(header_out) > 1){
-        keyvalues_out = Rfits::Rfits_hdr_to_keyvalues(header_out)
-      }
-    }else{
-      stop("The Rfits package is need to process the header_out. Install from GitHub asgr/Rfits.")
+    if(length(header_out) == 1){
+      keyvalues_out = Rfits_header_to_keyvalues(Rfits_raw_to_header(header_out))
+    }else if(length(header_out) > 1){
+      keyvalues_out = Rfits_hdr_to_keyvalues(header_out)
     }
   }
-  if(is.character(header_in)){
-    if(requireNamespace("Rfits", quietly = TRUE)){
-      if(length(header_in) == 1){
-        keyvalues_in = Rfits::Rfits_header_to_keyvalues(Rfits::Rfits_raw_to_header(header_in))
-      }else if(length(header_in) > 1){
-        keyvalues_in = Rfits::Rfits_hdr_to_keyvalues(header_in)
-      }
-    }else{
-      stop("The Rfits package is need to process the header_in Install from GitHub asgr/Rfits.")
-    }
-  }
+
+  # if(is.character(header_in)){
+  #   if(length(header_in) == 1){
+  #     keyvalues_in = Rfits_header_to_keyvalues(Rfits_raw_to_header(header_in))
+  #   }else if(length(header_in) > 1){
+  #     keyvalues_in = Rfits_hdr_to_keyvalues(header_in)
+  #   }
+  # }
 
   if(is.null(keyvalues_out) & is.null(header_out)){
     keyvalues_out = options()$current_keyvalues
@@ -105,50 +83,81 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
     stop('Missing NAXIS1 / NAXIS2 in header keyvalues! Specify dim_out.')
   }
 
-  if(!is.null(magzero_in) & !is.null(magzero_out)){
-    image_in = image_in*10^(-0.4*(magzero_in - magzero_out))
-    keyvalues_out$MAGZERO = magzero_out
-  }
-
   raw_out = header_out
 
   if(is.null(raw_out)){
-    header_out = Rfits::Rfits_keyvalues_to_header(keyvalues_out)
+    header_out = Rfits_keyvalues_to_header(keyvalues_out)
   }else{
-    header_out = Rfits::Rfits_raw_to_header(raw_out)
+    header_out = Rfits_raw_to_header(raw_out)
   }
 
   if(dotightcrop){
     suppressMessages({
-      BL = Rwcs_p2s(0, 0, keyvalues = keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
-      TL = Rwcs_p2s(0, dim(image_in)[2], keyvalues = keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
-      TR = Rwcs_p2s(dim(image_in)[1], dim(image_in)[2], keyvalues = keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
-      BR = Rwcs_p2s(dim(image_in)[1], 0, keyvalues = keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
+      BL_out = Rwcs_p2s(0, 0, keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
+      TL_out = Rwcs_p2s(0, dim_out[2], keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
+      TR_out = Rwcs_p2s(dim_out[1], dim_out[2], keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
+      BR_out = Rwcs_p2s(dim_out[1], 0, keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
     })
-    corners = rbind(BL, TL, TR, BR)
-    tightcrop = ceiling(Rwcs_s2p(corners, keyvalues = keyvalues_out, header=raw_out, pixcen='R', WCSref=WCSref_out))
-    min_x = max(1L, min(tightcrop[,1]))
-    max_x = max(min_x + dim(image_in)[1] - 1L, range(tightcrop[,1])[2])
-    min_y = max(1L, min(tightcrop[,2]))
-    max_y = max(min_y + dim(image_in)[2] - 1L, range(tightcrop[,2])[2])
-    #image_out = image_out[c(min_x, max_x), c(min_y, max_y)]
+
+    corners_out = rbind(BL_out, TL_out, TR_out, BR_out)
+    tightcrop_out = ceiling(Rwcs_s2p(corners_out, keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in))
+
+    min_x_out = max(1L, min(tightcrop_out[,1]))
+    max_x_out = min(dim(image_in)[1], max(tightcrop_out[,1]))
+    min_y_out = max(1L, min(tightcrop_out[,2]))
+    max_y_out = min(dim(image_in)[2], max(tightcrop_out[,2]))
+
+    if(min_x_out != 1 | max_x_out != dim(image_in)[1] | min_y_out != 1 | max_y_out != dim(image_in)[2]){
+      if(inherits(image_in, 'Rfits_pointer')){
+        image_in = image_in[c(min_x_out, max_x_out), c(min_y_out, max_y_out), header=TRUE]
+      }else{
+        image_in = image_in[c(min_x_out, max_x_out), c(min_y_out, max_y_out)]
+      }
+
+      keyvalues_in = image_in$keyvalues
+      if(is.null(image_in$raw)){
+        header_in = image_in$hdr
+      }else{
+        header_in = image_in$raw
+      }
+    }else{
+      if(inherits(image_in, 'Rfits_pointer')){
+        image_in = image_in[,]
+      }
+    }
+
+    suppressMessages({
+      BL_in = Rwcs_p2s(0, 0, keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
+      TL_in = Rwcs_p2s(0, dim(image_in)[2], keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
+      TR_in = Rwcs_p2s(dim(image_in)[1], dim(image_in)[2], keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
+      BR_in = Rwcs_p2s(dim(image_in)[1], 0, keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
+    })
+
+    corners_in = rbind(BL_in, TL_in, TR_in, BR_in)
+    tightcrop_in = ceiling(Rwcs_s2p(corners_in, keyvalues = keyvalues_out, header=raw_out, pixcen='R', WCSref=WCSref_out))
+
+    min_x_in = max(1L, min(tightcrop_in[,1]))
+    max_x_in = max(min_x_in + dim(image_in)[1] - 1L, range(tightcrop_in[,1])[2])
+    min_y_in = max(1L, min(tightcrop_in[,2]))
+    max_y_in = max(min_y_in + dim(image_in)[2] - 1L, range(tightcrop_in[,2])[2])
+
     # new code should be more efficient!
 
     if(!isTRUE(keyvalues_out$ZIMAGE)){
-      keyvalues_out$NAXIS1 = max_x - min_x + 1L
-      keyvalues_out$NAXIS2 = max_y - min_y + 1L
+      keyvalues_out$NAXIS1 = max_x_in - min_x_in + 1L
+      keyvalues_out$NAXIS2 = max_y_in - min_y_in + 1L
     }else{
-      keyvalues_out$ZNAXIS1 = max_x - min_x + 1L
-      keyvalues_out$ZNAXIS2 = max_y - min_y + 1L
+      keyvalues_out$ZNAXIS1 = max_x_in - min_x_in + 1L
+      keyvalues_out$ZNAXIS2 = max_y_in - min_y_in + 1L
     }
 
-    keyvalues_out$CRPIX1 = keyvalues_out$CRPIX1 - min_x + 1L
-    keyvalues_out$CRPIX2 = keyvalues_out$CRPIX2 - min_y + 1L
+    keyvalues_out$CRPIX1 = keyvalues_out$CRPIX1 - min_x_in + 1L
+    keyvalues_out$CRPIX2 = keyvalues_out$CRPIX2 - min_y_in + 1L
 
     image_out = list(
-      imDat = matrix(c(blank,image_in[0]), max_x - min_x + 1L, max_y - min_y + 1L),
+      imDat = matrix(c(blank,image_in$imDat[0]), max_x_in - min_x_in + 1L, max_y_in - min_y_in + 1L),
       keyvalues = keyvalues_out,
-      hdr = Rfits::Rfits_keyvalues_to_hdr(keyvalues_out),
+      hdr = Rfits_keyvalues_to_hdr(keyvalues_out),
       header = header_out,
       raw = raw_out,
       keynames = names(keyvalues_out),
@@ -162,10 +171,14 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
       raw_out = image_out$raw
     }
   }else{
+    if(inherits(image_in, 'Rfits_pointer')){
+      image_in = image_in[,]
+    }
+
     image_out = list(
-      imDat = matrix(c(blank,image_in[0]), max(dim(image_in)[1], dim_out[1]), max(dim(image_in)[2], dim_out[2])),
+      imDat = matrix(c(blank,image_in$imDat[0]), max(dim(image_in)[1], dim_out[1]), max(dim(image_in)[2], dim_out[2])),
       keyvalues = keyvalues_out,
-      hdr = Rfits::Rfits_keyvalues_to_hdr(keyvalues_out),
+      hdr = Rfits_keyvalues_to_hdr(keyvalues_out),
       header = header_out,
       raw = raw_out,
       keynames = names(keyvalues_out),
@@ -174,24 +187,26 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
     names(image_out$keycomments) = image_out$keynames
     class(image_out) = c('Rfits_image', class(image_out))
 
-    min_x = 1L
-    max_x = dim_out[1]
-    min_y = 1L
-    max_y = dim_out[2]
+    min_x_in = 1L
+    max_x_in = dim_out[1]
+    min_y_in = 1L
+    max_y_in = dim_out[2]
   }
 
-  dim_min_x = min(dim(image_in)[1], dim(image_out$imDat)[1])
-  dim_min_y = min(dim(image_in)[2], dim(image_out$imDat)[2])
+  dim_min_x_in = min(dim(image_in)[1], dim(image_out$imDat)[1])
+  dim_min_y_in = min(dim(image_in)[2], dim(image_out$imDat)[2])
 
-  image_out$imDat[1:dim_min_x, 1:dim_min_y] = image_in[1:dim_min_x, 1:dim_min_y]
+  image_out$imDat[1:dim_min_x_in, 1:dim_min_y_in] = image_in$imDat[1:dim_min_x_in, 1:dim_min_y_in]
+  rm(image_in)
+
+  if(!is.null(magzero_in) & !is.null(magzero_out)){
+    image_out$imDat = image_out$imDat*10^(-0.4*(magzero_in - magzero_out))
+    keyvalues_out$MAGZERO = magzero_out
+  }
 
   suppressMessages({
-    if(is.null(pixscale_in)){
-      pixscale_in = Rwcs_pixscale(keyvalues=keyvalues_in)
-    }
-    if(is.null(pixscale_out)){
-      pixscale_out = Rwcs_pixscale(keyvalues=keyvalues_out)
-    }
+    pixscale_in = Rwcs_pixscale(keyvalues=keyvalues_in)
+    pixscale_out = Rwcs_pixscale(keyvalues=keyvalues_out)
   })
 
   if (direction == "auto") {
@@ -206,11 +221,6 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
   if(is.null(warpfield)){
     pix_grid = expand.grid(1:dim(image_out$imDat)[1], 1:dim(image_out$imDat)[2])
 
-    #if (direction == "forward") {
-    #image_out$imDat = imager::imwarp(im = imager::as.cimg(image_out$imDat),
-    #                     map = function(x,y){.warpfunc_in2out(x,y)}, direction = direction, coordinates = "absolute",
-    #                     boundary = boundary, interpolation = interpolation)
-
     if (direction == "forward") {
       warp_out = .warpfunc_in2out(
         x = pix_grid[, 1],
@@ -220,7 +230,8 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
         WCSref_in = WCSref_in,
         keyvalues_out = keyvalues_out,
         raw_out = raw_out,
-        WCSref_out = WCSref_out
+        WCSref_out = WCSref_out,
+        cores = cores
       )
     } else if (direction == 'backward') {
       warp_out = .warpfunc_out2in(
@@ -231,7 +242,8 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
         WCSref_in = WCSref_in,
         keyvalues_out = keyvalues_out,
         raw_out = raw_out,
-        WCSref_out = WCSref_out
+        WCSref_out = WCSref_out,
+        cores = cores
       )
     }
 
@@ -296,29 +308,44 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
   image_out$imDat = as.matrix(image_out$imDat)
 
   if(dotightcrop==FALSE | keepcrop==FALSE){
-    image_out = image_out[c(1L - (min_x - 1L), dim_out[1] - (min_x - 1L)),c(1L - (min_y - 1L), dim_out[2] - (min_y - 1L)), box=1] #box=1 just in case we have a single pixel left
+    image_out = image_out[c(1L - (min_x_in - 1L), dim_out[1] - (min_x_in - 1L)),c(1L - (min_y_in - 1L), dim_out[2] - (min_y_in - 1L)), box=1] #box=1 just in case we have a single pixel left
     image_out$keyvalues$XCUTLO = 1L
     image_out$keyvalues$XCUTHI = dim_out[1]
     image_out$keyvalues$YCUTLO = 1L
     image_out$keyvalues$YCUTHI = dim_out[2]
   }else{
 
-    if(max_x > dim_out[1]){
-      trim_x = max_x - dim_out[1]
+    if(max_x_in > dim_out[1]){
+      trim_x = max_x_in - dim_out[1]
       image_out = image_out[1:(dim(image_out)[1] - trim_x), , box=1] #box=1 just in case we have a single pixel left
-      max_x = dim_out[1]
+      max_x_in = dim_out[1]
     }
 
-    if(max_y > dim_out[2]){
-      trim_y = max_y - dim_out[2]
+    if(max_y_in > dim_out[2]){
+      trim_y = max_y_in - dim_out[2]
       image_out = image_out[, 1:(dim(image_out)[2] - trim_y), box=1] #box=1 just in case we have a single pixel left
-      max_y = dim_out[2]
+      max_y_in = dim_out[2]
     }
 
-    image_out$keyvalues$XCUTLO = min_x
-    image_out$keyvalues$XCUTHI = max_x
-    image_out$keyvalues$YCUTLO = min_y
-    image_out$keyvalues$YCUTHI = max_y
+    final_pix = which(!is.na(image_out$imDat), arr.ind = TRUE)
+    crop_x_lo = min(final_pix[,1])
+    crop_x_hi = max(final_pix[,1])
+    crop_y_lo = min(final_pix[,2])
+    crop_y_hi = max(final_pix[,2])
+
+    #final extra tight crop
+    image_out = image_out[c(crop_x_lo, crop_x_hi), c(crop_y_lo, crop_y_hi)]
+
+    #update where we are in the parent frame
+    min_x_in = min_x_in + crop_x_lo - 1L
+    max_x_in = min_x_in + dim(image_out)[1] -1L
+    min_y_in = min_y_in + crop_y_lo - 1L
+    max_y_in = min_y_in + dim(image_out)[2] -1L
+
+    image_out$keyvalues$XCUTLO = min_x_in
+    image_out$keyvalues$XCUTHI = max_x_in
+    image_out$keyvalues$YCUTLO = min_y_in
+    image_out$keyvalues$YCUTHI = max_y_in
 
     image_out$keycomments$XCUTLO = 'Low image x range'
     image_out$keycomments$XCUTHI = 'High image x range'
@@ -330,11 +357,11 @@ propaneWarp = function(image_in, keyvalues_out=NULL, keyvalues_in = NULL, dim_ou
     image_out$keynames['YCUTLO'] = 'YCUTLO'
     image_out$keynames['YCUTHI'] = 'YCUTHI'
 
-    image_out$crop = c(xlo=min_x, xhi=max_x, ylo=min_y, yhi=max_y) #we want to keep the subset location for potential later writing
+    image_out$crop = c(xlo=min_x_in, xhi=max_x_in, ylo=min_y_in, yhi=max_y_in) #we want to keep the subset location for potential later writing
   }
 
-  if (plot) {
-    Rwcs_image(image_out, ...)
+  if(plot){
+    plot(image_out, ...)
   }
 
   if(warpfield_return){
@@ -369,9 +396,9 @@ propaneRebin = function(image, scale = 1,interpolation = 6){
     image_out = list(
       imDat = image_resize,
       keyvalues = keyvalues_out,
-      hdr = Rfits::Rfits_keyvalues_to_hdr(keyvalues_out),
-      header = Rfits::Rfits_keyvalues_to_header(keyvalues_out),
-      raw = Rfits::Rfits_header_to_raw(Rfits::Rfits_keyvalues_to_header(keyvalues_out)),
+      hdr = Rfits_keyvalues_to_hdr(keyvalues_out),
+      header = Rfits_keyvalues_to_header(keyvalues_out),
+      raw = Rfits_header_to_raw(Rfits_keyvalues_to_header(keyvalues_out)),
       keynames = names(keyvalues_out),
       keycomments = as.list(rep('', length(keyvalues_out)))
     )

--- a/man/propaneStackWarp.Rd
+++ b/man/propaneStackWarp.Rd
@@ -23,7 +23,7 @@ propaneStackWarpMed(filelist = NULL, dirlist = NULL, extlist = 1,
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{image_list}{
-List; required. List of the input \code{Rfits_image} or \code{Rfits_pointer} objects. Masked pixels can be flagged with NA in the imDat component. See Details below.
+List; required. List of the input \code{Rfits_image} or \code{Rfits_pointer} objects to be warped and stacked. Masked pixels can be flagged with NA in the imDat component. See Details below. Note that the header information attached to the \option{image_list} is used for \option{inVar_list}, \option{exp_list}, \option{weight_list} and \option{mask_list} as appropriate.
 }
   \item{inVar_list}{
 Numeric vector or list of numeric matrices / \code{Rfits_image} / \code{Rfits_pointer}; optional. The inverse variances. Either one value per \option{image_list} entry, or one pixel matched matrix per \option{image_list} entry. This is used to achieve S/N weighted stacking. If not provided then images are stacked with equal weight. See Details below.

--- a/man/propaneWarp.Rd
+++ b/man/propaneWarp.Rd
@@ -13,12 +13,11 @@ Remaps an input projection system to a different target WCS.
 \code{propaneWarp} does precise remapping of one WCS to another, \code{propaneRebin} does quick coarse down-sampling (via re-binning), which can be useful for faster visualisations (since fewer pixels to worry about). Both conserve flux correctly. \code{propaneTran} just applies a translational shift. \code{propaneWarpProPane} warps all elements of a ProPane class object (as returned by e.g. \code{\link{propaneStackWarpInVar}}).
 }
 \usage{
-propaneWarp(image_in, keyvalues_out = NULL, keyvalues_in = NULL, dim_out = NULL,
-  pixscale_out = NULL, pixscale_in = NULL, direction = "auto", boundary = "dirichlet",
-  interpolation = "cubic", doscale = TRUE, dofinenorm = TRUE, plot = FALSE,
-  header_out = NULL, header_in = NULL, dotightcrop = TRUE, keepcrop = FALSE,
+propaneWarp(image_in, keyvalues_out = NULL, dim_out = NULL, direction = "auto",
+  boundary = "dirichlet", interpolation = "cubic", doscale = TRUE, dofinenorm = TRUE,
+  plot = FALSE, header_out = NULL, dotightcrop = TRUE, keepcrop = FALSE,
   WCSref_out = NULL, WCSref_in = NULL, magzero_out = NULL, magzero_in = NULL,
-  blank = NA, warpfield = NULL, warpfield_return = FALSE, ...)
+  blank = NA, warpfield = NULL, warpfield_return = FALSE, cores = 1, ...)
 
 propaneWarpProPane(propane_in, keyvalues_out = NULL, dim_out = NULL,
   magzero_out = NULL, ...)
@@ -31,28 +30,19 @@ propaneTran(image, delta_x = 0, delta_y = 0, direction = 'backward', padNA = TRU
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{image_in}{
-Numeric matrix; required, the image we want to warp. If \option{image} is a list as created by \code{Rfits_read_image} then the image part of the list is parsed to \option{image} and the correct header part is parsed to \option{keyvalues}.
+List; required, the image we want to warp. \option{image_in} must be either object class Rfits_image or Rfits_pointer, i.e. as read in by \code{\link{Rfits_read_image}}.
 }
   \item{propane_in}{
 List; object of class 'ProPane', e.g. the output of \code{\link{propaneStackWarpInVar}}. All present list elements will be warp as appropriate (so conserving flux, inverse-Variance, or value as required): image (flux), weight (value), inVar (rebinned inVar), exp (value), cold (flux), hot (flux), clip (value).
 }
   \item{image}{
-Numeric matrix; required, the image we want to rebin. If \option{image} is a list as created by \code{Rfits_read_image} then the image part of the list is parsed to \option{image} and the correct header part is parsed to \option{keyvalues}.
+Numeric matrix; required, the image we want to rebin. If \option{image} is a list as created by \code{Rfits_read_image} then the imDat part of the list is parsed to \option{image} and the correct header part is parsed to \option{keyvalues}.
 }
   \item{keyvalues_out}{
 List; output header values to be used for the WCS. This is the target WCS projection that \option{image_in} will be mapped onto.
 }
-  \item{keyvalues_in}{
-List; input header values to be used for the WCS. This should be the header WCS that matches \option{image_in}.
-}
   \item{dim_out}{
 Integer vector; this defines the desired dimensions of the output image. If this is not provided then the output image is made to be the same size as the NAXIS1 and NAXIS2 arguments taken from \option{header_out} (which is usually what you will want TBH).
-}
-  \item{pixscale_out}{
-Numeric scalar; output pixel scale in asec/pixel. If not provided it will be computed from the \option{keyvalues_out} using \code{\link{Rwcs_pixscale}}, which is only an issue if the CD matrix is defined a long way from the actual projected image which can lead to distorted pixel scales.
-}
-  \item{pixscale_in}{
-Numeric scalar; input pixel scale in asec/pixel. If not provided it will be computed from the \option{keyvalues_in} using \code{\link{Rwcs_pixscale}}, which is only an issue if the CD matrix is defined a long way from the actual projected image which can lead to distorted pixel scales.
 }
   \item{direction}{
 Character scalar; "auto" (default), "forward" or "backward", see \code{imwarp}. Since it is usally better to go from the higher resolution image and map this onto the lower resolution grid, "auto" selects the better direction given the pixel scales recovered from the header information.
@@ -74,9 +64,6 @@ Logical; should a \code{\link{Rwcs_image}} plot of the output be generated?
 }
   \item{header_out}{
 Optional output header. To aid backwards compatibility, you can also pass in a 1D character vector of header values, e.g. the \option{hdr} component of \option{readFITS} from the \code{FITSio} package. \option{keyvalues_out} must be left as NULL in this case. If you want to use all distortion terms you can also pass in the raw header output of \code{Rfits_read_header_raw}.
-}
-  \item{header_in}{
-Optional input header. To aid backwards compatibility, you can also pass in a 1D character vector of header values, e.g. the \option{hdr} component of \option{readFITS} from the \code{FITSio} package. \option{keyvalues_in} must be left as NULL in this case. If you want to use all distortion terms you can also pass in the raw header output of \code{Rfits_read_header_raw}.
 }
   \item{dotightcrop}{
 Logical; should an internal tight crop be made. If the images are approximately the same angular size this should be left as FALSE (it will run faster), but when there is a big difference between the input and output WCS (the latter being much larger) then setting this to TRUE might speed the warping up a lot.
@@ -119,6 +106,9 @@ Cimg imager_array; a warp field to be used. You almost very certainly never want
 }
   \item{warpfield_return}{
 Logical; should a \option{warpfield} be appended to the output list? This can be used later with the \option{warpfield} argument to speed up identical WCS warping operations.
+}
+  \item{cores}{
+Integer scalar; the number of cores to run on. Because of the overhead in launching jobs, running in multicore mode is rarely much faster, and always uses significantly more RAM. Probably rarely useful! The caveat would be when 1e8 length inputs are being provided (e.g. a 10k x 10k image warp)- at this scale the multicore mode can be a factor of a few faster.
 }
   \item{\dots}{
 For \code{propaneWarp} dots are passed to \code{\link{Rwcs_image}} (only relevant if \option{plot}=TRUE). For \code{propaneWarpProPane} dots are passed to \code{propaneWarp}.


### PR DESCRIPTION
We now only warp pixels that can possibly end up on the target WCS (was previously doing the whole input frame). We also compute a tighter crop after warping, since sometimes input images are rotated (East up in and North up out).

The tighter crop has been checked against VISTA and KiDS stacks (all looks good).