### PR TITLE
Clean up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ProPane
 Type: Package
 Title: Image Warping Stacking and Tweaking
 Version: 1.3.6
-Date: 2023-05-25
+Date: 2023-05-26
 Authors@R: c(
     person(given='Aaron', family='Robotham', email='aaron.robotham@uwa.edu.au',
         role=c('aut', 'cre'), comment=c(ORCID='0000-0003-0429-3579')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ProPane
 Type: Package
 Title: Image Warping Stacking and Tweaking
-Version: 1.3.6
-Date: 2023-05-26
+Version: 1.3.7
+Date: 2023-05-30
 Authors@R: c(
     person(given='Aaron', family='Robotham', email='aaron.robotham@uwa.edu.au',
         role=c('aut', 'cre'), comment=c(ORCID='0000-0003-0429-3579')),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,6 +9,7 @@ export(propaneWCSmod)
 #Image stacking routines:
 export(propaneStackWarpInVar)
 export(propaneStackWarpMed)
+export(propaneStackWarpFunc)
 export(propaneStackFlatInVar)
 export(propaneStackFlatFunc)
 export(propanePatch)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,6 +8,7 @@ export(propaneWCSmod)
 
 #Image stacking routines:
 export(propaneStackWarpInVar)
+export(propaneWarpDump)
 export(propaneStackWarpMed)
 export(propaneStackWarpFunc)
 export(propaneStackFlatInVar)

--- a/R/propaneStackWarpMed.R
+++ b/R/propaneStackWarpMed.R
@@ -316,12 +316,17 @@ propaneStackWarpFunc = function(
       }
     }
 
-    if(doweight){
+    if(doweight | tolower(imager_func) == 'invar'){
       weight_list = foreach(j = 1:length(image_list_cut))%do%{
         return(imager::as.cimg(!is.na(image_list_cut[[j]])))
       }
 
       weight = as.matrix(imager::add(weight_list))
+
+      if(tolower(imager_func) == 'invar'){
+        image = image*(weight - 1)
+        image[weight < 2] = NA
+      }
     }else{
       weight = NULL
     }

--- a/R/propaneStackWarpMed.R
+++ b/R/propaneStackWarpMed.R
@@ -175,3 +175,208 @@ propaneStackWarpMed = function(
   class(output) = "ProPane"
   return(invisible(output))
 }
+
+propaneStackWarpFunc = function(
+    filelist = NULL,
+    dirlist = NULL,
+    extlist = 1,
+    pattern = NULL,
+    recursive = TRUE,
+    zap = NULL,
+    keyvalues_out = NULL,
+    imager_func = NULL,
+    probs = c(0.159, 0.5, 0.841),
+    cores = 4,
+    chunk = 1e3,
+    doweight = TRUE,
+    useCUTLO = TRUE){
+
+  timestart = proc.time()[3]
+
+  j = NULL
+
+  assertList(keyvalues_out, null.ok = TRUE)
+  assertIntegerish(cores, len=1)
+  assertIntegerish(chunk, len=1)
+
+  if(!requireNamespace("Rfits", quietly = TRUE)){
+    stop('The Rfits package is needed for stacking to work. Please install from GitHub asgr/Rfits.', call. = FALSE)
+  }
+
+  if(!requireNamespace("imager", quietly = TRUE)){
+    stop('The imager package is needed for stacking to work. Please install from GitHub asgr/Rfits.', call. = FALSE)
+  }
+
+  if(is.null(imager_func)){
+    imager_func = imager::average
+  }
+
+  registerDoParallel(cores=cores)
+
+  image_list = Rfits_make_list(filelist = filelist,
+                               dirlist = dirlist,
+                               extlist = extlist,
+                               pattern = pattern,
+                               recursive = recursive,
+                               pointer = TRUE,
+                               cores = cores,
+                               zap = zap)
+
+  if(!is.null(keyvalues_out)){
+    which_overlap = which(foreach(i = 1:length(image_list), .combine='c')%dopar%{
+      Rwcs_overlap(image_list[[i]]$keyvalues, keyvalues_ref = keyvalues_out, buffer=0)
+    })
+    image_list = image_list[which_overlap]
+  }else{
+    which_overlap = 1:length(image_list)
+    temp_overlap = 1:length(image_list)
+  }
+
+  if(!is.null(keyvalues_out)){
+    if(isTRUE(keyvalues_out$ZIMAGE)){
+      NAXIS1 = keyvalues_out$ZNAXIS1
+      NAXIS2 = keyvalues_out$ZNAXIS2
+    }else{
+      NAXIS1 = keyvalues_out$NAXIS1
+      NAXIS2 = keyvalues_out$NAXIS2
+    }
+  }else{
+    NAXIS1 = dim(image_list[[1]])[1]
+    NAXIS2 = dim(image_list[[1]])[2]
+  }
+
+  stack_grid = expand.grid(seq(1L,NAXIS1,by=chunk), seq(1L,NAXIS2,by=chunk))
+  stack_grid[,3] = stack_grid[,1] + chunk
+  stack_grid[stack_grid[,3] > NAXIS1,3] = NAXIS1
+  stack_grid[,4] = stack_grid[,2] + chunk
+  stack_grid[stack_grid[,4] > NAXIS2,4] = NAXIS2
+
+  stack_func = foreach(i = 1:dim(stack_grid)[1])%dopar%{
+    #for(i in 1:dim(stack_grid)[1]){
+    message('Stacking sub region ',i,' of ',dim(stack_grid)[1])
+
+    xsub = as.integer(stack_grid[i, c(1,3)])
+    ysub = as.integer(stack_grid[i, c(2,4)])
+
+    if(!is.null(keyvalues_out)){
+      keyvalues_sub = Rwcs_keyvalues_sub(keyvalues_out, xsub=xsub, ysub=ysub)
+
+      temp_overlap = which(foreach(j = 1:length(image_list), .combine = 'c')%dopar%{
+        Rwcs_overlap(image_list[[j]]$keyvalues, keyvalues_sub, buffer=0)
+      })
+    }
+
+    if(length(temp_overlap) == 0L){
+      return(
+        list(
+          image = matrix(NA_real_, diff(range(xsub)) + 1L, diff(range(ysub)) + 1L),
+          weight = matrix(0L, diff(range(xsub)) + 1L, diff(range(ysub)) + 1L)
+        )
+      )
+    }
+
+    image_list_cut = foreach(j = temp_overlap)%do%{ #not sure why this won't work in dopar... Rfits race conditions?
+      if(!is.null(image_list[[j]]$keyvalues$XCUTLO) & useCUTLO){
+        XCUTLO = image_list[[j]]$keyvalues$XCUTLO
+      }else{
+        XCUTLO = 1L #implictly assumed to be aligned images if XCUTLO is missing
+      }
+
+      if(!is.null(image_list[[j]]$keyvalues$YCUTLO) & useCUTLO){
+        YCUTLO = image_list[[j]]$keyvalues$YCUTLO
+      }else{
+        YCUTLO = 1L #implictly assumed to be aligned images if YCUTLO is missing
+      }
+
+      xrange = c(1,(diff(range(xsub)) + 1L)) + (xsub[1] - XCUTLO)
+      yrange = c(1,(diff(range(ysub)) + 1L)) + (ysub[1] - YCUTLO)
+      return(imager::as.cimg(image_list[[j]][xrange, yrange]$imDat))
+    }
+
+    if(is.function(imager_func)){
+      if('na.rm' %in% names(formals(imager_func))){
+        image = as.matrix(imager_func(image_list_cut, na.rm=TRUE))
+      }else{
+        image = as.matrix(imager_func(image_list_cut))
+      }
+    }else{
+      if(tolower(imager_func) == 'invar'){
+        image = 1/as.matrix(imager::parvar(image_list_cut, na.rm=TRUE))
+      }
+
+      if(tolower(imager_func) == 'quantile' | tolower(imager_func) == 'quan' ){
+        im_dim = dim(image_list_cut[[1]])
+        temp_mat = matrix(as.numeric(unlist(image_list_cut)), nrow=length(image_list_cut), byrow = TRUE)
+
+        image = list()
+        for(k in 1:length(probs)){
+          temp_out = apply(temp_mat, MARGIN=2, FUN=quantile, probs=probs[k], na.rm=TRUE)
+          image = c(image, list(matrix(temp_out, im_dim[1], im_dim[2])))
+        }
+      }
+    }
+
+    if(doweight){
+      weight_list = foreach(j = 1:length(image_list_cut))%do%{
+        return(imager::as.cimg(!is.na(image_list_cut[[j]])))
+      }
+
+      weight = as.matrix(imager::add(weight_list))
+    }else{
+      weight = NULL
+    }
+
+    return(
+      list(image = image, weight = weight)
+    )
+  }
+
+  image_out = matrix(0, NAXIS1, NAXIS2)
+  if(doweight){
+    weight_out = matrix(0L, NAXIS1, NAXIS2)
+  }else{
+    weight_out = NULL
+  }
+
+  for(i in 1:dim(stack_grid)[1]){
+    image_out[stack_grid[i,1]:stack_grid[i,3], stack_grid[i,2]:stack_grid[i,4]] = stack_func[[i]]$image
+    if(doweight){
+      weight_out[stack_grid[i,1]:stack_grid[i,3], stack_grid[i,2]:stack_grid[i,4]] = stack_func[[i]]$weight
+    }
+  }
+
+  if(!is.null(keyvalues_out)){
+    keyvalues_out$EXTNAME = 'image'
+    keyvalues_out$MAGZERO = image_list[[1]]$keyvalues$MAGZERO
+    keyvalues_out$R_VER = R.version$version.string
+    keyvalues_out$PANE_VER = as.character(packageVersion('ProPane'))
+    keyvalues_out$RWCS_VER = as.character(packageVersion('Rwcs'))
+
+    image_out = Rfits_create_image(image=image_out,
+                                   keyvalues=keyvalues_out,
+                                   keypass=FALSE,
+                                   history='Stacked with Rwcs_stack')
+
+    if(doweight){
+      keyvalues_out$EXTNAME = 'weight'
+      keyvalues_out$MAGZERO = NULL
+      weight_out = Rfits_create_image(image=weight_out,
+                                      keyvalues=keyvalues_out,
+                                      keypass=FALSE)
+    }
+  }
+
+  time_taken = proc.time()[3] - timestart
+  message('Time taken: ',signif(time_taken,4),' seconds')
+
+  output = list(
+    image = image_out,
+    weight = weight_out,
+    which_overlap = which_overlap,
+    time = time_taken,
+    Nim = length(which_overlap)
+  )
+
+  class(output) = "ProPane"
+  return(invisible(output))
+}

--- a/R/propaneWarp.R
+++ b/R/propaneWarp.R
@@ -180,6 +180,8 @@ propaneWarp = function(image_in, keyvalues_out=NULL, header_out=NULL, dim_out = 
     corners_in = rbind(BL_in, TL_in, TR_in, BR_in)
     tightcrop_in = ceiling(Rwcs_s2p(corners_in, header=header_out, pixcen='R', WCSref=WCSref_out))
 
+    print(tightcrop_in)
+
     min_x_in = max(1L, min(tightcrop_in[,1]))
     max_x_in = max(min_x_in + dim(image_in)[1] - 1L, range(tightcrop_in[,1])[2])
     min_y_in = max(1L, min(tightcrop_in[,2]))

--- a/R/propaneWarp.R
+++ b/R/propaneWarp.R
@@ -1,17 +1,17 @@
-.warpfunc_in2out = function(x, y, keyvalues_in=NULL, header_in=NULL, WCSref_in=NULL, keyvalues_out=NULL, raw_out=NULL, WCSref_out=NULL, cores=1) {
-  radectemp = Rwcs_p2s(x, y, keyvalues = keyvalues_in, header = header_in, WCSref = WCSref_in, cores = cores)
-  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], keyvalues = keyvalues_out, header = raw_out, WCSref = WCSref_out, cores = cores)
+.warpfunc_in2out = function(x, y, header_in=NULL, WCSref_in=NULL, header_out=NULL, WCSref_out=NULL, cores=1) {
+  radectemp = Rwcs_p2s(x, y, header = header_in, WCSref = WCSref_in, cores = cores)
+  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], header = header_out, WCSref = WCSref_out, cores = cores)
   return(xy_out)
 }
-.warpfunc_out2in = function(x, y, keyvalues_in=NULL, header_in=NULL, WCSref_in=NULL, keyvalues_out=NULL, raw_out=NULL, WCSref_out=NULL, cores=1) {
-  radectemp = Rwcs_p2s(x, y, keyvalues = keyvalues_out, header = raw_out, WCSref = WCSref_in, cores = cores)
-  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], keyvalues = keyvalues_in, header = header_in, WCSref = WCSref_out, cores = cores)
+.warpfunc_out2in = function(x, y, header_in=NULL, WCSref_in=NULL, header_out=NULL, WCSref_out=NULL, cores=1) {
+  radectemp = Rwcs_p2s(x, y, header = header_out, WCSref = WCSref_in, cores = cores)
+  xy_out = Rwcs_s2p(radectemp[,1], radectemp[,2], header = header_in, WCSref = WCSref_out, cores = cores)
   return(xy_out)
 }
 
-propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
+propaneWarp = function(image_in, keyvalues_out=NULL, header_out=NULL, dim_out = NULL,
                       direction = "auto", boundary = "dirichlet", interpolation = "cubic",
-                      doscale = TRUE, dofinenorm = TRUE, plot = FALSE, header_out = NULL, dotightcrop = TRUE,
+                      doscale = TRUE, dofinenorm = TRUE, plot = FALSE, dotightcrop = TRUE,
                       keepcrop = FALSE, extratight = FALSE, WCSref_out = NULL, WCSref_in = NULL,
                       magzero_out = NULL, magzero_in = NULL, blank=NA, warpfield=NULL,
                       warpfield_return=FALSE, cores=1, checkWCSequal=FALSE, ...)
@@ -33,13 +33,19 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
   }
 
   keyvalues_in = image_in$keyvalues
-  if(is.null(image_in$raw)){
-    header_in = image_in$hdr
-  }else{
-    header_in = image_in$raw
-  }
+  keyvalues_in = keyvalues_in[!is.na(keyvalues_in)]
+  header_in = Rfits_header_to_raw(Rfits_keyvalues_to_header(keyvalues_in))
+
+  # if(is.null(image_in$raw)){
+  #   header_in = image_in$hdr
+  # }else{
+  #   header_in = image_in$raw
+  # }
 
   if(is.character(header_out)){
+    if(!is.null(keyvalues_out)){
+      message('Using header_out and ignoring keyvalues_out!')
+    }
     if(length(header_out) == 1){
       keyvalues_out = Rfits_header_to_keyvalues(Rfits_raw_to_header(header_out))
     }else if(length(header_out) > 1){
@@ -60,7 +66,6 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
     header_out = options()$current_header
   }
 
-  keyvalues_in = keyvalues_in[!is.na(keyvalues_in)]
   keyvalues_out = keyvalues_out[!is.na(keyvalues_out)]
 
   if(checkWCSequal){
@@ -88,15 +93,19 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
       image_in$keyvalues$YCUTLO = 1L
       image_in$keyvalues$YCUTHI = dim(image_in)[2]
 
-      image_in$keycomments$XCUTLO = 'Low image x range'
-      image_in$keycomments$XCUTHI = 'High image x range'
-      image_in$keycomments$YCUTLO = 'Low image y range'
-      image_in$keycomments$YCUTHI = 'High image y range'
+      image_in$hdr = Rfits_keyvalues_to_hdr(image_in$keyvalues)
+      image_in$header = Rfits_keyvalues_to_header(image_in$keyvalues)
+      image_in$raw = Rfits_header_to_raw(Rfits_keyvalues_to_header(image_in$keyvalues))
 
       image_in$keynames['XCUTLO'] = 'XCUTLO'
       image_in$keynames['XCUTHI'] = 'XCUTHI'
       image_in$keynames['YCUTLO'] = 'YCUTLO'
       image_in$keynames['YCUTHI'] = 'YCUTHI'
+
+      image_in$keycomments$XCUTLO = 'Low image x range'
+      image_in$keycomments$XCUTHI = 'High image x range'
+      image_in$keycomments$YCUTLO = 'Low image y range'
+      image_in$keycomments$YCUTHI = 'High image y range'
 
       return(invisible(image_in))
     }
@@ -123,24 +132,18 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
     stop('Missing NAXIS1 / NAXIS2 in header keyvalues! Specify dim_out.')
   }
 
-  raw_out = header_out
-
-  if(is.null(raw_out)){
-    header_out = Rfits_keyvalues_to_header(keyvalues_out)
-  }else{
-    header_out = Rfits_raw_to_header(raw_out)
-  }
+  header_out = Rfits_header_to_raw(Rfits_keyvalues_to_header(keyvalues_out))
 
   if(dotightcrop){
     suppressMessages({
-      BL_out = Rwcs_p2s(0, 0, keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
-      TL_out = Rwcs_p2s(0, dim_out[2], keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
-      TR_out = Rwcs_p2s(dim_out[1], dim_out[2], keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
-      BR_out = Rwcs_p2s(dim_out[1], 0, keyvalues=keyvalues_out, header=header_out, pixcen='R', WCSref=WCSref_out)
+      BL_out = Rwcs_p2s(0, 0, header=header_out, pixcen='R', WCSref=WCSref_out)
+      TL_out = Rwcs_p2s(0, dim_out[2], header=header_out, pixcen='R', WCSref=WCSref_out)
+      TR_out = Rwcs_p2s(dim_out[1], dim_out[2], header=header_out, pixcen='R', WCSref=WCSref_out)
+      BR_out = Rwcs_p2s(dim_out[1], 0, header=header_out, pixcen='R', WCSref=WCSref_out)
     })
 
     corners_out = rbind(BL_out, TL_out, TR_out, BR_out)
-    tightcrop_out = ceiling(Rwcs_s2p(corners_out, keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in))
+    tightcrop_out = ceiling(Rwcs_s2p(corners_out, header=header_in, pixcen='R', WCSref=WCSref_in))
 
     min_x_out = max(1L, min(tightcrop_out[,1]))
     max_x_out = min(dim(image_in)[1], max(tightcrop_out[,1]))
@@ -155,11 +158,12 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
       }
 
       keyvalues_in = image_in$keyvalues
-      if(is.null(image_in$raw)){
-        header_in = image_in$hdr
-      }else{
-        header_in = image_in$raw
-      }
+      header_in = Rfits_header_to_raw(Rfits_keyvalues_to_header(keyvalues_in))
+      # if(is.null(image_in$raw)){
+      #   header_in = image_in$hdr
+      # }else{
+      #   header_in = image_in$raw
+      # }
     }else{
       if(inherits(image_in, 'Rfits_pointer')){
         image_in = image_in[,]
@@ -167,14 +171,14 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
     }
 
     suppressMessages({
-      BL_in = Rwcs_p2s(0, 0, keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
-      TL_in = Rwcs_p2s(0, dim(image_in)[2], keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
-      TR_in = Rwcs_p2s(dim(image_in)[1], dim(image_in)[2], keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
-      BR_in = Rwcs_p2s(dim(image_in)[1], 0, keyvalues=keyvalues_in, header=header_in, pixcen='R', WCSref=WCSref_in)
+      BL_in = Rwcs_p2s(0, 0, header=header_in, pixcen='R', WCSref=WCSref_in)
+      TL_in = Rwcs_p2s(0, dim(image_in)[2], header=header_in, pixcen='R', WCSref=WCSref_in)
+      TR_in = Rwcs_p2s(dim(image_in)[1], dim(image_in)[2], header=header_in, pixcen='R', WCSref=WCSref_in)
+      BR_in = Rwcs_p2s(dim(image_in)[1], 0, header=header_in, pixcen='R', WCSref=WCSref_in)
     })
 
     corners_in = rbind(BL_in, TL_in, TR_in, BR_in)
-    tightcrop_in = ceiling(Rwcs_s2p(corners_in, keyvalues = keyvalues_out, header=raw_out, pixcen='R', WCSref=WCSref_out))
+    tightcrop_in = ceiling(Rwcs_s2p(corners_in, header=header_out, pixcen='R', WCSref=WCSref_out))
 
     min_x_in = max(1L, min(tightcrop_in[,1]))
     max_x_in = max(min_x_in + dim(image_in)[1] - 1L, range(tightcrop_in[,1])[2])
@@ -198,18 +202,18 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
       imDat = matrix(c(blank,image_in$imDat[0]), max_x_in - min_x_in + 1L, max_y_in - min_y_in + 1L),
       keyvalues = keyvalues_out,
       hdr = Rfits_keyvalues_to_hdr(keyvalues_out),
-      header = header_out,
-      raw = raw_out,
+      header = Rfits_keyvalues_to_header(keyvalues_out),
+      raw = Rfits_header_to_raw(Rfits_keyvalues_to_header(keyvalues_out)),
       keynames = names(keyvalues_out),
       keycomments = as.list(rep('', length(keyvalues_out)))
     )
     names(image_out$keycomments) = image_out$keynames
     class(image_out) = c('Rfits_image', class(image_out))
 
-    keyvalues_out = image_out$keyvalues
-    if(!is.null(raw_out)){
-      raw_out = image_out$raw
-    }
+    # keyvalues_out = image_out$keyvalues
+    # if(!is.null(raw_out)){
+    #   raw_out = image_out$raw
+    # }
   }else{
     if(inherits(image_in, 'Rfits_pointer')){
       image_in = image_in[,]
@@ -219,8 +223,8 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
       imDat = matrix(c(blank,image_in$imDat[0]), max(dim(image_in)[1], dim_out[1]), max(dim(image_in)[2], dim_out[2])),
       keyvalues = keyvalues_out,
       hdr = Rfits_keyvalues_to_hdr(keyvalues_out),
-      header = header_out,
-      raw = raw_out,
+      header = Rfits_keyvalues_to_header(keyvalues_out),
+      raw = Rfits_header_to_raw(Rfits_keyvalues_to_header(keyvalues_out)),
       keynames = names(keyvalues_out),
       keycomments = as.list(rep('', length(keyvalues_out)))
     )
@@ -265,11 +269,9 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
       warp_out = .warpfunc_in2out(
         x = pix_grid[, 1],
         y = pix_grid[, 2],
-        keyvalues_in = keyvalues_in,
         header_in = header_in,
         WCSref_in = WCSref_in,
-        keyvalues_out = keyvalues_out,
-        raw_out = raw_out,
+        header_out = header_out,
         WCSref_out = WCSref_out,
         cores = cores
       )
@@ -277,14 +279,16 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
       warp_out = .warpfunc_out2in(
         x = pix_grid[, 1],
         y = pix_grid[, 2],
-        keyvalues_in = keyvalues_in,
         header_in = header_in,
         WCSref_in = WCSref_in,
-        keyvalues_out = keyvalues_out,
-        raw_out = raw_out,
+        header_out = header_out,
         WCSref_out = WCSref_out,
         cores = cores
       )
+    }
+
+    if(anyInfinite(warp_out)){
+      stop('Bad warp field!')
     }
 
     warpfield = imager::imappend(list(imager::as.cimg(matrix(
@@ -354,12 +358,16 @@ propaneWarp = function(image_in, keyvalues_out=NULL, dim_out = NULL,
     image_out$keyvalues$YCUTLO = 1L
     image_out$keyvalues$YCUTHI = dim_out[2]
 
+    image_out$hdr = Rfits_keyvalues_to_hdr(image_out$keyvalues)
+    image_out$header = Rfits_keyvalues_to_header(image_out$keyvalues)
+    image_out$raw = Rfits_header_to_raw(Rfits_keyvalues_to_header(image_out$keyvalues))
+
+    image_out$keynames = names(image_out$keyvalues)
+
     image_out$keycomments$XCUTLO = 'Low image x range'
     image_out$keycomments$XCUTHI = 'High image x range'
     image_out$keycomments$YCUTLO = 'Low image y range'
     image_out$keycomments$YCUTHI = 'High image y range'
-
-    image_out$keynames = names(image_out$keyvalues)
   }else{
 
     if(max_x_in > dim_out[1]){

--- a/R/propaneWarpDump.R
+++ b/R/propaneWarpDump.R
@@ -1,0 +1,109 @@
+propaneWarpDump = function(image_list=NULL, magzero_in=0, magzero_out=23.9, keyvalues_out=NULL,
+                           dim_out=NULL, cores=4, cores_warp=1, keepcrop=TRUE,
+                           dump_dir=tempdir(), ...){
+
+  if(!requireNamespace("Rfits", quietly = TRUE)){
+    stop('The Rfits package is needed for stacking to work. Please install from GitHub asgr/Rfits.', call. = FALSE)
+  }
+
+  if(!requireNamespace("Rwcs", quietly = TRUE)){
+    stop('The Rfits package is needed for stacking to work. Please install from GitHub asgr/Rfits.', call. = FALSE)
+  }
+
+  dump_dir = path.expand(dump_dir)
+  if(dir.exists(dump_dir) == FALSE){
+    dir.create(dump_dir, recursive = TRUE)
+  }
+  message('Frames being dumped to ', dump_dir)
+
+  registerDoParallel(cores=cores)
+
+  Nim = length(image_list)
+
+  if(length(magzero_in) == 1){
+    magzero_in = rep(magzero_in, Nim)
+  }
+
+  if(is.null(keyvalues_out)){
+    keyvalues_out = image_list[[1]]$keyvalues
+  }
+
+  if(is.null(keyvalues_out)){
+    stop('Need keyvalues out!')
+  }
+
+  if(isTRUE(keyvalues_out$ZIMAGE)){
+    dim_im = c(keyvalues_out$ZNAXIS1, keyvalues_out$ZNAXIS2)
+  }else{
+    dim_im = c(keyvalues_out$NAXIS1, keyvalues_out$NAXIS2)
+  }
+
+  # Check all supplied frames are in WCS:
+
+  i = NULL
+  which_overlap = which(foreach(i = 1:Nim, .combine='c')%dopar%{
+    Rwcs_overlap(image_list[[i]]$keyvalues, keyvalues_ref = keyvalues_out, buffer=0)
+  })
+
+  Ncheck = length(which_overlap)
+
+  if(Ncheck == 0){
+    message('No frames exist within target WCS!')
+    return(NULL)
+  }
+
+  if(Nim > Ncheck){
+    message('Only ', Ncheck, ' of ', Nim, ' input frames overlap with target WCS!')
+
+    Nim = Ncheck
+
+    # Trim down all the inputs to just those overlapping with the target WCS:
+
+    image_list = image_list[which_overlap]
+
+
+    magzero_in = magzero_in[which_overlap]
+  }
+
+  zero_point_scale = 10^(-0.4*(magzero_in - magzero_out))
+
+  message('Projecting Images 1 to ', Nim)
+
+  foreach(i = 1:Nim)%dopar%{
+    if(inherits(image_list[[i]], 'Rfits_pointer')){
+      temp_image = image_list[[i]][,]
+    }else{
+      temp_image = image_list[[i]]
+    }
+
+    if(any(!is.finite(temp_image$imDat))){
+      temp_image$imDat[!is.finite(temp_image$imDat)] = NA
+    }
+
+    suppressMessages({
+      temp_warp = propaneWarp(
+        image_in = temp_image,
+        keyvalues_out = keyvalues_out,
+        dim_out = dim_out,
+        doscale = TRUE,
+        dotightcrop = TRUE,
+        keepcrop = keepcrop,
+        warpfield_return = TRUE,
+        cores = cores_warp,
+        ...
+      )
+
+      if(zero_point_scale[i] != 1){
+        temp_warp$imDat = temp_warp$imDat*zero_point_scale[i]
+      }
+
+      temp_warp$keyvalues$MAGZERO = magzero_out
+      temp_warp$keycomments$MAGZERO = ""
+      temp_warp$keynames['MAGZERO'] = "MAGZERO"
+      Rfits_write_image(temp_warp, paste0(dump_dir,'/image_warp_',i,'.fits'))
+    })
+    return(NULL)
+  }
+
+  return(dump_dir)
+}

--- a/man/propaneStackWarp.Rd
+++ b/man/propaneStackWarp.Rd
@@ -1,6 +1,7 @@
 \name{propaneStackWarp}
 \alias{propaneStackWarp}
 \alias{propaneStackWarpInVar}
+\alias{propaneWarpDump}
 \alias{propaneStackWarpMed}
 \alias{propaneStackWarpFunc}
 %- Also NEED an '\alias' for EACH other topic documented here.
@@ -16,6 +17,10 @@ propaneStackWarpInVar(image_list = NULL, inVar_list = NULL, exp_list = NULL,
   keyvalues_out = NULL, dim_out = NULL, cores = 4, cores_warp = 1, Nbatch = cores,
   keepcrop = TRUE, keep_extreme_pix = FALSE, doclip = FALSE, clip_tol = 100,
   clip_dilate = 0, clip_sigma = 5, return_all = FALSE, dump_frames = FALSE,
+  dump_dir = tempdir(), ...)
+
+propaneWarpDump(image_list = NULL, magzero_in = 0, magzero_out = 23.9,
+  keyvalues_out = NULL, dim_out = NULL, cores = 4, cores_warp = 1, keepcrop = TRUE,
   dump_dir = tempdir(), ...)
 
 propaneStackWarpMed(filelist = NULL, dirlist = NULL, extlist = 1,
@@ -53,7 +58,7 @@ Numeric scalar; the output mag-zero point desired. A nice \option{magzero_out} i
 List; output header values to be used for the WCS. This is the target WCS projection that each image in \option{image_list} will be mapped onto.
 }
   \item{imager_func}{
-Function (or character scalar for special case); the \code{imager} combine function to apply. This can be any of the ones in ?imager.combine. The default of NULL means it will use the \code{average} function. As a special case you can use \option{imager_func} = 'quantile' / 'quan' (with the speech marks) for quantiles (defined by \option{pro}). Also, \option{imager_func} = 'InVar' (with speech marks) will return the inverse variance image (which is what we use for general stacking).
+Function (or character scalar for special case); the \code{imager} combine function to apply. This can be any of the ones in ?imager.combine. The default of NULL means it will use the \code{average} function. As a special case you can use \option{imager_func} = 'quantile' / 'quan' (with the speech marks) for quantiles (defined by \option{pro}). Also, \option{imager_func} = 'InVar' (with speech marks) will return the inverse variance image scaled correctly by exposures (which is what we use for general stacking).
 }
   \item{probs}{
 Numeric vector; quantile probabilites between 0-1. This is only used in the specific case of \option{imager_func} = 'quantile' / 'quan' (with the speech marks).
@@ -129,6 +134,8 @@ Other arguments to pass into \code{\link{propaneWarp}}.
 }
 }
 \details{
+\code{propaneStackWarpInVar} is an inverse variance weighted image stacking function, which has a lot of flexibility in terms of clipping and weighting.
+
 The warping code used here is \code{\link{propaneWarp}}, and the stacking part is very similar to that used in \code{\link{propaneStackFlatInVar}}. It uses inverse-variance weighted stacking when \option{inVar_list} is provided, and a simple average stack otherwise.
 
 \option{image_list} can be provided as a list of \code{Rfits_image} or \code{Rfits_pointer}. The advantage of the former is raw speed (no disk IO required) but the advantage of the latter is memory footprint (only the required pixels are loaded at any given stage of stacking).
@@ -141,11 +148,13 @@ Which route is better to use depends on the memory available- passing in in-memo
 
 Care needs to be taken to choose appropriate values for \option{cores} and \option{Nbatch}. Ultimately at least a few copies of the full target image will need to be kept in memory at some point in this stacking process, since the stacking happens in RAM not on disk. For that reason there is an upper limit on how big the target image can be without hitting some pretty brutal performance issues (when you start using disk swap, things become very very slow). As an idea, a 10k x 10k pixel image with bitpix = -32 (sinlge precision) will take up 400 MB on disk and loaded in \code{R} 800 MB (since \code{R} only supports double precision floats internally). This means a 40k x 40k will require 12.8 GB of RAM. Given that number at least doubles during any \code{\link{propaneWarp}} process, and we possibly have a weight map and exposure to compute, you want to be pretty certain that x4 this value fits well within half of available RAM even if we are using \code{Nbatch} = 1. Even on a machine with 128 GB of RAM (my local machine) that is about as big an image as we could possibly target for stacking.
 
+\code{propaneWarpDump} just caries out the frame warping and dumping part of \code{propaneStackWarpInVar}.
+
 \code{propaneStackWarpMed} is a dedicated median combine stacking function. The difference in operation is that it only works on pre-dumped frames that will have been projected with \code{propaneStackWarpInVar} with the \option{dump_frames} option set to TRUE. The reason for this is that the median combine can generally only be run on quite small chunked subsets (usually in the range 1000 - 2000 and set with the \option{chunk} argument). Warping on the fly to such subsets is expensive (for reasonable sized inputs most pixels get thrown away each time), so it is faster to compute frame overlap on the dumped frames and combine them together as needed. The actual median combine is done using the \code{parmed} function of the \code{imager} package. If this has been compiled with OpenMP flags then you will also see massive speed up during the combining phase. The keen user will probably need to do some Googling to get this right, but for large stacking it could be worth the effort (for MacOS check out https://mac.r-project.org/openmp/).
 
 \code{propaneStackWarpMed} can also be 'tricked' into stacking non-WCS aligned images. This might be useful when you are e.g. stacking stars that are on inherently different WCS, but you have already cutout and centred then. For this to work no \option{keyvalues_out} should be provided, and \option{useCUTLO} should be set to FALSE (just incase you have XCUTLO and YCUTLO keyvalues produced by \code{Rfits} in your header). The images to be stacked also need to be the same exact dimensions (as well as being centred sensibly on your source of interest, of course).
 
-\code{propaneStackWarpFunc} is like a generic version of \code{propaneStackWarpMed}, where any of the ?imager.combine functions that collapse stacks of images down can be used rather than just \code{parmed} (which is the median function used in \code{propaneStackWarpMed}). For that reason, setting \option{imager_func} = imager::parmed will replicated exactly the behaviour of \code{propaneStackWarpMed}. Useful options to consider using are imager::parvar (variance) and imager::parsd (standard deviation). As a special case you can use \option{imager_func} = 'quantile' / 'quan' (with the speech marks) for quantiles (defined by \option{pro}). Also, \option{imager_func} = 'InVar' (with speech marks) will return the inverse variance image (which is what we use for general stacking).
+\code{propaneStackWarpFunc} is like a generic version of \code{propaneStackWarpMed}, where any of the ?imager.combine functions that collapse stacks of images down can be used rather than just \code{parmed} (which is the median function used in \code{propaneStackWarpMed}). For that reason, setting \option{imager_func} = imager::parmed will replicated exactly the behaviour of \code{propaneStackWarpMed}. Useful options to consider using are imager::parvar (variance) and imager::parsd (standard deviation). As a special case you can use \option{imager_func} = 'quantile' / 'quan' (with the speech marks) for quantiles (defined by \option{pro}). Also, \option{imager_func} = 'InVar' (with speech marks) will return the inverse variance image scaled correctly by exposures (which is what we use for general stacking).
 }
 \value{
 The output of \code{propaneStackWarpInVar} is an object of class 'ProPane' containing:
@@ -274,7 +283,7 @@ sd(stack2$image$imDat[stack2$image$imDat < 0.3], na.rm=TRUE) #stack 2
 #Pretty similar! Note when changing pixel scales a lot this can be wrong due to pixel
 #covariance, which we do not correct for.
 
-#For median stacking we need to dum out the frames:
+#For median stacking we need to dump out the frames:
 
 stack3 = propaneStackWarpInVar(image_list = image_list,
                               inVar_list = 0.000468, #assume all have the same inVar
@@ -290,6 +299,25 @@ stack_med = propaneStackWarpMed(dirlist=stack3$dump_dir,
   keyvalues_out=stack3$image$keyvalues, pattern=glob2rx('*image_warp*'))
 
 plot(stack_med$image, qdiff=T)
+
+#And we can measure the quantiles too:
+
+stack_invar = propaneStackWarpFunc(dirlist=stack3$dump_dir,
+  keyvalues_out=stack3$image$keyvalues, imager_func = 'InVar',
+  pattern=glob2rx('*image_warp*'))
+
+#With a bit of thought, we can use this stack_invar in ProFound:
+library(ProFound)
+
+InVar = stack_invar$image$imDat
+InVar = profoundImBlur(InVar) #Smooth out the InVar measurements a bit
+
+#Run ProFound masking out regions where only 0/1 image contributes:
+
+test_pro = profoundProFound(stack_mask, skyRMS = 1/sqrt(InVar),
+  mask = stack3$weight$imDat < 2, redosky = F)
+
+plot(test_pro)
 }
 }
 \concept{ ~warp }

--- a/man/propaneStackWarp.Rd
+++ b/man/propaneStackWarp.Rd
@@ -2,6 +2,7 @@
 \alias{propaneStackWarp}
 \alias{propaneStackWarpInVar}
 \alias{propaneStackWarpMed}
+\alias{propaneStackWarpFunc}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
 Image Warping and Stacking
@@ -20,6 +21,10 @@ propaneStackWarpInVar(image_list = NULL, inVar_list = NULL, exp_list = NULL,
 propaneStackWarpMed(filelist = NULL, dirlist = NULL, extlist = 1,
   pattern = NULL, recursive = TRUE, zap = NULL, keyvalues_out = NULL,
   cores = 4, chunk = 1e3, doweight = TRUE, useCUTLO = TRUE)
+
+propaneStackWarpFunc(filelist = NULL, dirlist = NULL, extlist = 1,
+  pattern = NULL, recursive = TRUE, zap = NULL, keyvalues_out = NULL, imager_func = NULL,
+  probs = c(0.159, 0.5, 0.841), cores = 4, chunk = 1e3, doweight = TRUE, useCUTLO = TRUE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -46,6 +51,12 @@ Numeric scalar; the output mag-zero point desired. A nice \option{magzero_out} i
 }
   \item{keyvalues_out}{
 List; output header values to be used for the WCS. This is the target WCS projection that each image in \option{image_list} will be mapped onto.
+}
+  \item{imager_func}{
+Function (or character scalar for special case); the \code{imager} combine function to apply. This can be any of the ones in ?imager.combine. The default of NULL means it will use the \code{average} function. As a special case you can use \option{imager_func} = 'quantile' / 'quan' (with the speech marks) for quantiles (defined by \option{pro}). Also, \option{imager_func} = 'InVar' (with speech marks) will return the inverse variance image (which is what we use for general stacking).
+}
+  \item{probs}{
+Numeric vector; quantile probabilites between 0-1. This is only used in the specific case of \option{imager_func} = 'quantile' / 'quan' (with the speech marks).
 }
   \item{dim_out}{
 Integer vector; this defines the desired dimensions of the output image. If this is not provided then the output image is made to be the same size as the NAXIS1 and NAXIS2 arguments taken from \option{header_out} (which is usually what you will want TBH).
@@ -133,6 +144,8 @@ Care needs to be taken to choose appropriate values for \option{cores} and \opti
 \code{propaneStackWarpMed} is a dedicated median combine stacking function. The difference in operation is that it only works on pre-dumped frames that will have been projected with \code{propaneStackWarpInVar} with the \option{dump_frames} option set to TRUE. The reason for this is that the median combine can generally only be run on quite small chunked subsets (usually in the range 1000 - 2000 and set with the \option{chunk} argument). Warping on the fly to such subsets is expensive (for reasonable sized inputs most pixels get thrown away each time), so it is faster to compute frame overlap on the dumped frames and combine them together as needed. The actual median combine is done using the \code{parmed} function of the \code{imager} package. If this has been compiled with OpenMP flags then you will also see massive speed up during the combining phase. The keen user will probably need to do some Googling to get this right, but for large stacking it could be worth the effort (for MacOS check out https://mac.r-project.org/openmp/).
 
 \code{propaneStackWarpMed} can also be 'tricked' into stacking non-WCS aligned images. This might be useful when you are e.g. stacking stars that are on inherently different WCS, but you have already cutout and centred then. For this to work no \option{keyvalues_out} should be provided, and \option{useCUTLO} should be set to FALSE (just incase you have XCUTLO and YCUTLO keyvalues produced by \code{Rfits} in your header). The images to be stacked also need to be the same exact dimensions (as well as being centred sensibly on your source of interest, of course).
+
+\code{propaneStackWarpFunc} is like a generic version of \code{propaneStackWarpMed}, where any of the ?imager.combine functions that collapse stacks of images down can be used rather than just \code{parmed} (which is the median function used in \code{propaneStackWarpMed}). For that reason, setting \option{imager_func} = imager::parmed will replicated exactly the behaviour of \code{propaneStackWarpMed}. Useful options to consider using are imager::parvar (variance) and imager::parsd (standard deviation). As a special case you can use \option{imager_func} = 'quantile' / 'quan' (with the speech marks) for quantiles (defined by \option{pro}). Also, \option{imager_func} = 'InVar' (with speech marks) will return the inverse variance image (which is what we use for general stacking).
 }
 \value{
 The output of \code{propaneStackWarpInVar} is an object of class 'ProPane' containing:
@@ -260,6 +273,23 @@ sd(stack2$image$imDat[stack2$image$imDat < 0.3], na.rm=TRUE) #stack 2
 
 #Pretty similar! Note when changing pixel scales a lot this can be wrong due to pixel
 #covariance, which we do not correct for.
+
+#For median stacking we need to dum out the frames:
+
+stack3 = propaneStackWarpInVar(image_list = image_list,
+                              inVar_list = 0.000468, #assume all have the same inVar
+                              exp_list = 10, #all have the same exposure time of 10s
+                              cores = 8,
+                              keyvalues_out = keyvalues_out,
+                              magzero_in = 30,
+                              magzero_out = 23.9, #micro-jansky output
+                              dump_frames = TRUE #for median stacking test
+)
+
+stack_med = propaneStackWarpMed(dirlist=stack3$dump_dir,
+  keyvalues_out=stack3$image$keyvalues, pattern=glob2rx('*image_warp*'))
+
+plot(stack_med$image, qdiff=T)
 }
 }
 \concept{ ~warp }

--- a/man/propaneWarp.Rd
+++ b/man/propaneWarp.Rd
@@ -14,9 +14,9 @@ Remaps an input projection system to a different target WCS.
 \code{propaneWarp} does precise remapping of one WCS to another, \code{propaneRebin} does quick coarse down-sampling (via re-binning), which can be useful for faster visualisations (since fewer pixels to worry about). Both conserve flux correctly. \code{propaneTran} just applies a translational shift and rotation. \code{propaneWarpProPane} warps all elements of a ProPane class object (as returned by e.g. \code{\link{propaneStackWarpInVar}}).
 }
 \usage{
-propaneWarp(image_in, keyvalues_out = NULL, dim_out = NULL, direction = "auto",
-  boundary = "dirichlet", interpolation = "cubic", doscale = TRUE, dofinenorm = TRUE,
-  plot = FALSE, header_out = NULL, dotightcrop = TRUE, keepcrop = FALSE,
+propaneWarp(image_in, keyvalues_out = NULL, header_out = NULL, dim_out = NULL,
+  direction = "auto", boundary = "dirichlet", interpolation = "cubic", doscale = TRUE,
+  dofinenorm = TRUE, plot = FALSE, dotightcrop = TRUE, keepcrop = FALSE,
   extratight = FALSE, WCSref_out = NULL, WCSref_in = NULL, magzero_out = NULL,
   magzero_in = NULL, blank = NA, warpfield = NULL, warpfield_return = FALSE, cores = 1,
   checkWCSequal = FALSE, ...)
@@ -48,6 +48,9 @@ List; required, the WCS to fix. Can be one of Rfits_keylist, Rfits_image, Rfits_
   \item{keyvalues_out}{
 List; output header values to be used for the WCS. This is the target WCS projection that \option{image_in} will be mapped onto.
 }
+  \item{header_out}{
+Optional output header. To aid backwards compatibility, you can also pass in a 1D character vector of header values, e.g. the \option{hdr} component of \option{Rfits_read_image} from the \code{Rfits} package. If you want to use all distortion terms you can also pass in the raw header output of \code{Rfits_read_header_raw} (which is also the raw list component of an Rfits_image or Rfits_pointer object). If this is present then \option{keyvalues_out} will be ignored!
+}
   \item{dim_out}{
 Integer vector; this defines the desired dimensions of the output image. If this is not provided then the output image is made to be the same size as the NAXIS1 and NAXIS2 arguments taken from \option{header_out} (which is usually what you will want TBH).
 }
@@ -68,9 +71,6 @@ Logical; if TRUE (default) then the image is scaled by the relative change the c
 }
   \item{plot}{
 Logical; should a \code{\link{Rwcs_image}} plot of the output be generated?
-}
-  \item{header_out}{
-Optional output header. To aid backwards compatibility, you can also pass in a 1D character vector of header values, e.g. the \option{hdr} component of \option{readFITS} from the \code{FITSio} package. \option{keyvalues_out} must be left as NULL in this case. If you want to use all distortion terms you can also pass in the raw header output of \code{Rfits_read_header_raw} (which is also the raw list component of an Rfits_image or Rfits_pointer object).
 }
   \item{dotightcrop}{
 Logical; should an internal tight crop be made. If the images are approximately the same angular size this should be left as FALSE (it will run faster), but when there is a big difference between the input and output WCS (the latter being much larger) then setting this to TRUE might speed the warping up a lot.


### PR DESCRIPTION
Some simpler tidier propaneWarp code (had not really been updated since it was Rwc_warp).

New propaneStackWarpFunc, to allow generic imager stacking combine functions (like parvar, parsd etc).

New propaneWarpDump, to purely dump warped snippets.